### PR TITLE
Moved onChange into callback for setState

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.js
+++ b/packages/core/src/components/DatePicker/DatePicker.js
@@ -96,6 +96,7 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
       const newDate = this.getControlledDate(nextProps)
       if (!isEqualDate(this.state.date, newDate)) {
         const { defaultFormat, showCustomError, errorMessage } = nextProps
+        
         this.setState({
           date: newDate,
           showCustomError,
@@ -151,6 +152,7 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
   handleTextFieldChange = (value: string) => {
     const prevState = this.state
     const { minDate, maxDate, formatDate, defaultFormat, onChange, showCustomError, errorMessage: customError } = this.props
+
     const { displayDate, date = prevState.date, errorMessage } = validateDateAndGetErrorMesssage(
       value,
       minDate,
@@ -158,15 +160,17 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
       formatDate || this.formatDate,
       defaultFormat,
     )
+
     const finalError = this.getErrorMessage(value, errorMessage, showCustomError, customError)
+
     this.setState({
       ...prevState,
       date,
       displayDate,
       errorMessage: finalError,
-    })
-    onChange && onChange(displayDate, date)
+    }, () => onChange && onChange(displayDate, date))    
   }
+  
   isControlled() {
     return this.props.hasOwnProperty('value')
   }
@@ -228,9 +232,10 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
       defaultFormat,
       formatDate: formatDateProp,
       ...other
-		} = this.props
-
+    } = this.props
+    
     const formatDate = formatDateProp || this.formatDate
+
     const renderDateIcon = disabled === false ? {
       onRenderSuffix: () => (
         <IconButton style={{ margin: '-15px' }} onClick={this.handleClick}>
@@ -238,6 +243,7 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
         </IconButton>
       )
     } : {}
+
     return (
       <div className={className}>
         <TextField


### PR DESCRIPTION
Fix #105 
The asynchronous nature of setState was preventing errorMessage from being properly pushed into state due to onChange executing before setState was finished. So I moved onChange to a callback and min and max date errors are now properly showing.

Example:
![40273006_286370008826685_4218232405267316736_n](https://user-images.githubusercontent.com/10966992/44771496-be0b6d80-ab30-11e8-802d-85d20cc3a857.png)
![40298085_1183614805122587_3898519832936579072_n](https://user-images.githubusercontent.com/10966992/44771499-bf3c9a80-ab30-11e8-835a-15ddcfc36db1.png)
