### PR TITLE
Fixes for Currency Field to work as Controlled Component

### DIFF
--- a/packages/core/src/components/CurrencyField/CurrencyField.js
+++ b/packages/core/src/components/CurrencyField/CurrencyField.js
@@ -26,15 +26,8 @@ type CurrencyFieldPropTypes = {
   maxValue: number,
 }
 
-type CurrencyFieldValidationType = {
-  errorMessage: string,
-  formattedValue: string,
-  displayedValue: string,
-}
-
 type CurrencyFieldStateType = {
   errorMessage: string,
-  formattedValue: string,
   displayedValue: string,
 }
 
@@ -44,7 +37,6 @@ const validateInputValueAndReturnErrorMessage = (
   const { countryCode, maxValue } = props
   if (!countriesSupported.includes(countryCode)) {
     return {
-      formattedValue: currencyValue,
       displayedValue: currencyValue,
       errorMessage: 'Please enter/send a valid country',
     }
@@ -53,13 +45,11 @@ const validateInputValueAndReturnErrorMessage = (
     const formattedCurrency = formatCurrency(countryCode, currencyValue.toString(), country.currency)
     if (Number(currencyValue) > maxValue) {
       return {
-        formattedValue: formattedCurrency,
         displayedValue: formattedCurrency,
         errorMessage: `Max Limit ${formatCurrency(countryCode, maxValue.toString(), country.currency)}`,
       }
     } else {
       return {
-        formattedValue: formattedCurrency,
         displayedValue: formattedCurrency,
         errorMessage: '',
       }
@@ -110,11 +100,11 @@ export class CurrencyField extends Component<CurrencyFieldPropTypes, CurrencyFie
     this.setState(prevState => ({
       ...prevState,
       ...validatedInput,
-      displayedValue: validatedInput.formattedValue,
+      displayedValue: validatedInput.displayedValue,
     }), () => {
       if (this.props.onBlur) {
-        const { formattedValue } = this.state
-        this.props.onBlur(formattedValue, currencyValue.toString()) // To be consistent we return both strings
+        const { displayedValue } = this.state
+        this.props.onBlur(displayedValue, currencyValue.toString()) // To be consistent we return both strings
       }
     })
   }
@@ -147,7 +137,6 @@ export class CurrencyField extends Component<CurrencyFieldPropTypes, CurrencyFie
     const delimiter = country.delimiter
     const currencyValue = value.replace(/\D/g, match => (match === delimiter ? delimiter : ''))
     this.setState({
-      formattedValue: currencyValue.toString(),
       displayedValue: currencyValue.toString(),
       errorMessage: '',
     })
@@ -166,7 +155,7 @@ export class CurrencyField extends Component<CurrencyFieldPropTypes, CurrencyFie
           onFocus={e => this.onFocus(e.target.value)}
           errorMessage={this.state.errorMessage}
         />
-        <input type="hidden" name={this.props.name} required={this.props.required} value={this.state.formattedValue} />
+        <input type="hidden" name={this.props.name} required={this.props.required} value={this.state.displayedValue} />
       </div>
     )
   }

--- a/packages/core/src/components/CurrencyField/CurrencyField.md
+++ b/packages/core/src/components/CurrencyField/CurrencyField.md
@@ -1,6 +1,10 @@
-CurrencyField Example:
+CurrencyField:
 
+Uncontrolled Example:
+
+Useful when you want to have the component retaining it's own state
 ```js
+
 const companyCodeMapper = require('./countryMapper').default;
 const countryCode = 'DE';
 
@@ -11,6 +15,33 @@ const countryCode = 'DE';
     countryCode={countryCode}
     placeholder={companyCodeMapper(countryCode).placeHolder}
     maxValue={999999999.99}
+  />
+</div>
+```
+
+Controlled Example:
+
+Value set from parent as well as being set from within the component.
+
+OnBlur triggers the call to  update the parent state/Redux
+```js
+
+const companyCodeMapper = require('./countryMapper').default;
+const countryCode = 'DE';
+initialState = { value: 1234.56 };
+
+<div style={{ maxWidth: '300px' }}>
+  <CurrencyField
+    label={'Currency Field'}
+    disabled={false}
+    countryCode={countryCode}
+    placeholder={companyCodeMapper(countryCode).placeHolder}
+    maxValue={999999999.99}
+    value={state.value}
+    onBlur={(formattedValue, rawValue) => {
+      console.log(formattedValue, rawValue)
+      setState({ value: rawValue })
+    }}
   />
 </div>
 ```


### PR DESCRIPTION
Fix initial formatting of value for currency field. 
Update the onFocus and onBlur handlers to work across all countries.
Add controlled and uncontrolled example in the styleguide.

Fixes #121 