### PR TITLE
Fix/currency field tests

### DIFF
--- a/packages/core/src/components/AppBar/__tests__/__snapshots__/AppBar.test.js.snap
+++ b/packages/core/src/components/AppBar/__tests__/__snapshots__/AppBar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`<AppBar /> <AppBar /> renders properly 1`] = `
 <div
-  data-core-component="AppBar"
+  data-test="AppBar"
   style={
     Object {
       "WebkitTapHighlightColor": "rgba(0,0,0,0)",
@@ -40,16 +40,14 @@ exports[`<AppBar /> <AppBar /> renders properly 1`] = `
       <div
         className="appBarLeft"
       >
-        <img
-          alt="Copart"
-          className="logo"
-          src="./public/assets/images/logo.svg"
-        />
-        <span
-          className="moduleName"
+        <a
+          href="/"
         >
-          CAS Portal
-        </span>
+          <img
+            className="__CopartLogo-CopartLogo"
+            src="https://www.copart.com/images/logo.svg"
+          />
+        </a>
       </div>
     </div>
   </div>
@@ -80,8 +78,8 @@ exports[`<AppBar /> <AppBar /> renders properly 1`] = `
     style={
       Object {
         "marginLeft": "auto",
-        "marginRight": "-14px",
-        "marginTop": "14px",
+        "marginRight": -16,
+        "marginTop": 8,
         "muiPrepared": true,
       }
     }

--- a/packages/core/src/components/CurrencyField/__tests__/CurrencyField.test.js
+++ b/packages/core/src/components/CurrencyField/__tests__/CurrencyField.test.js
@@ -12,7 +12,7 @@ describe('<CurrencyField />', () => {
     countries.forEach((countryCode) => {
       const tree = mount(
         <CurrencyField
-          label={'Currency Field'}
+          label='Currency Field'
           disabled={false}
           countryCode={countryCode}
           placeholder={companyCodeMapper(countryCode).placeHolder}
@@ -25,47 +25,51 @@ describe('<CurrencyField />', () => {
 
   test('should throw error when maxValue is reached', () => {
     const countryCodeErrorMap = {
-      DE: 'Max Limit € 99.99',
+      DE: 'Max Limit 99,99\u00a0€',
       US: 'Max Limit $99.99',
       UK: 'Max Limit £99.99',
       IR: 'Max Limit €99.99',
-      CA: 'Max Limit CAD99.99',
-      IN: 'Max Limit ₹99.99',
+      CA: 'Max Limit CAD\u00a099.99',
+      IN: 'Max Limit ₹\u00a099.99',
       GB: 'Max Limit £99.99',
     }
-    Object.keys(countryCodeErrorMap).forEach((countryCode) => {
+
+    Object.entries(countryCodeErrorMap).forEach(([countryCode, expected]) => {
       const tree = mount(
         <CurrencyField
-          label={'Currency Field'}
+          label='Currency Field'
           disabled={false}
           countryCode={countryCode}
           placeholder={companyCodeMapper(countryCode).placeHolder}
           maxValue={99.99}
         />,
       )
+
       tree
         .find('TextField')
         .at(0)
         .prop('onChanged')('100.00')
-      expect(tree.state('errorMessage')).toBe(countryCodeErrorMap[countryCode])
+      
+      expect(tree.state('errorMessage')).toBe(expected)
     })
   })
 
   test('should return formatted currency value when entered value < maxValue', () => {
     const countryCodeErrorMap = {
-      DE: [ '€100,000.00', '100000' ],
+      DE: [ '100.000,00\u00a0€', '100000' ],
       US: [ '$100,000.00', '100000' ],
       UK: [ '£100,000.00', '100000' ],
       IR: [ '€100,000.00', '100000' ],
-      CA: [ 'CAD100,000.00', '100000' ],
-      IN: [ '₹100,000.00', '100000' ],
+      CA: [ 'CAD\u00a0100,000.00', '100000' ],
+      IN: [ '₹\u00a01,00,000.00', '100000' ],
       GB: [ '£100,000.00', '100000' ],
     }
-    Object.keys(countryCodeErrorMap).forEach((countryCode) => {
+    Object.entries(countryCodeErrorMap).forEach(([countryCode, expected]) => {
       const onBlur = jest.fn()
+
       const tree = mount(
         <CurrencyField
-          label={'Currency Field'}
+          label='Currency Field'
           disabled={false}
           countryCode={countryCode}
           placeholder={companyCodeMapper(countryCode).placeHolder}
@@ -73,34 +77,37 @@ describe('<CurrencyField />', () => {
           onBlur={onBlur}
         />,
       )
-      const expectedOutput = countryCodeErrorMap[countryCode]
+
       tree
         .find('TextField')
         .at(0)
         .prop('onBlur')({
           currentTarget: {
-            value: expectedOutput[1],
+            value: expected[1],
           },
         })
-      expect(onBlur).toHaveBeenCalledWith(expectedOutput[0], expectedOutput[1])
+      
+      expect(onBlur).toHaveBeenCalledWith(expected[0], expected[1])
     })
   })
 
   test('should display errorMessage onBlur when value entered > maxValue', () => {
     const countryCodeErrorMap = {
-      DE: [ 'Max Limit €9,999.99', '100000' ],
+      DE: [ 'Max Limit 9.999,99\u00a0€', '100000' ],
       US: [ 'Max Limit $9,999.99', '100000' ],
       UK: [ 'Max Limit £9,999.99', '100000' ],
       IR: [ 'Max Limit €9,999.99', '100000' ],
-      CA: [ 'Max Limit CAD 9,999.99', '100000' ],
-      IN: [ 'Max Limit ₹9,999.99', '100000' ],
+      CA: [ 'Max Limit CAD\u00a09,999.99', '100000' ],
+      IN: [ 'Max Limit ₹\u00a09,999.99', '100000' ],
       GB: [ 'Max Limit £9,999.99', '100000' ],
     }
-    Object.keys(countryCodeErrorMap).forEach((countryCode) => {
+
+    Object.entries(countryCodeErrorMap).forEach(([countryCode, expected]) => {
       const onBlur = jest.fn()
+  
       const tree = mount(
         <CurrencyField
-          label={'Currency Field'}
+          label='Currency Field'
           disabled={false}
           countryCode={countryCode}
           placeholder={companyCodeMapper(countryCode).placeHolder}
@@ -108,16 +115,17 @@ describe('<CurrencyField />', () => {
           onBlur={onBlur}
         />,
       )
-      const expectedOutput = countryCodeErrorMap[countryCode]
+
       tree
         .find('TextField')
         .at(0)
         .prop('onBlur')({
           currentTarget: {
-            value: expectedOutput[1],
+            value: expected[1],
           },
         })
-      expect(tree.state('errorMessage')).toBe(countryCodeErrorMap[countryCode][0])
+      
+      expect(tree.state('errorMessage')).toBe(expected[0])
     })
   })
 
@@ -126,11 +134,13 @@ describe('<CurrencyField />', () => {
       US: '',
       ZI: 'Please enter/send a valid country',
     }
-    Object.keys(countryToErrorMessage).forEach((countryCode) => {
+
+    Object.entries(countryToErrorMessage).forEach(([countryCode, expected]) => {
       const tree = mount(
-        <CurrencyField label={'Currency Field'} disabled={false} countryCode={countryCode} maxValue={99.99} />,
+        <CurrencyField label='Currency Field' disabled={false} countryCode={countryCode} maxValue={99.99} />,
       )
-      expect(tree.state('errorMessage')).toBe(countryToErrorMessage[countryCode])
+
+      expect(tree.state('errorMessage')).toBe(expected)
     })
   })
 })

--- a/packages/core/src/components/CurrencyField/__tests__/__snapshots__/CurrencyField.test.js.snap
+++ b/packages/core/src/components/CurrencyField/__tests__/__snapshots__/CurrencyField.test.js.snap
@@ -21,7 +21,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="$00,000,000.00"
-      value=""
+      value="$0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -183,6 +183,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -222,6 +223,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -243,11 +245,12 @@ exports[`<CurrencyField /> should render properly 1`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="$00,000,000.00"
-              value=""
+              value="$0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="US"
                 deferredValidationTime={200}
                 disabled={false}
@@ -268,10 +271,10 @@ exports[`<CurrencyField /> should render properly 1`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="$0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -439,6 +442,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -478,6 +482,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -507,7 +512,7 @@ exports[`<CurrencyField /> should render properly 1`] = `
                         onInput={[Function]}
                         placeholder="$00,000,000.00"
                         type="text"
-                        value=""
+                        value="$0.00"
                       />
                     </div>
                   </div>
@@ -547,7 +552,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="£00,000,000.00"
-      value=""
+      value="£0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -709,6 +714,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -748,6 +754,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -769,11 +776,12 @@ exports[`<CurrencyField /> should render properly 2`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="£00,000,000.00"
-              value=""
+              value="£0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="UK"
                 deferredValidationTime={200}
                 disabled={false}
@@ -794,10 +802,10 @@ exports[`<CurrencyField /> should render properly 2`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="£0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -965,6 +973,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -1004,6 +1013,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -1033,7 +1043,7 @@ exports[`<CurrencyField /> should render properly 2`] = `
                         onInput={[Function]}
                         placeholder="£00,000,000.00"
                         type="text"
-                        value=""
+                        value="£0.00"
                       />
                     </div>
                   </div>
@@ -1073,7 +1083,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="€00,000,000.00"
-      value=""
+      value="€0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -1235,6 +1245,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -1274,6 +1285,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -1295,11 +1307,12 @@ exports[`<CurrencyField /> should render properly 3`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="€00,000,000.00"
-              value=""
+              value="€0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="IR"
                 deferredValidationTime={200}
                 disabled={false}
@@ -1320,10 +1333,10 @@ exports[`<CurrencyField /> should render properly 3`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="€0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -1491,6 +1504,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -1530,6 +1544,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -1559,7 +1574,7 @@ exports[`<CurrencyField /> should render properly 3`] = `
                         onInput={[Function]}
                         placeholder="€00,000,000.00"
                         type="text"
-                        value=""
+                        value="€0.00"
                       />
                     </div>
                   </div>
@@ -1599,7 +1614,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="AED00,000,000.00"
-      value=""
+      value="AED 0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -1761,6 +1776,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -1800,6 +1816,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -1821,11 +1838,12 @@ exports[`<CurrencyField /> should render properly 4`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="AED00,000,000.00"
-              value=""
+              value="AED 0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="ME"
                 deferredValidationTime={200}
                 disabled={false}
@@ -1846,10 +1864,10 @@ exports[`<CurrencyField /> should render properly 4`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="AED 0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -2017,6 +2035,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -2056,6 +2075,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -2085,7 +2105,7 @@ exports[`<CurrencyField /> should render properly 4`] = `
                         onInput={[Function]}
                         placeholder="AED00,000,000.00"
                         type="text"
-                        value=""
+                        value="AED 0.00"
                       />
                     </div>
                   </div>
@@ -2125,7 +2145,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="CAD00,000,000.00"
-      value=""
+      value="CAD 0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -2287,6 +2307,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -2326,6 +2347,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -2347,11 +2369,12 @@ exports[`<CurrencyField /> should render properly 5`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="CAD00,000,000.00"
-              value=""
+              value="CAD 0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="CA"
                 deferredValidationTime={200}
                 disabled={false}
@@ -2372,10 +2395,10 @@ exports[`<CurrencyField /> should render properly 5`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="CAD 0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -2543,6 +2566,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -2582,6 +2606,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -2611,7 +2636,7 @@ exports[`<CurrencyField /> should render properly 5`] = `
                         onInput={[Function]}
                         placeholder="CAD00,000,000.00"
                         type="text"
-                        value=""
+                        value="CAD 0.00"
                       />
                     </div>
                   </div>
@@ -2651,7 +2676,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="00.000.000,00 €"
-      value=""
+      value="0,00 €"
     >
       <CustomizedFabric>
         <Fabric
@@ -2813,6 +2838,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -2852,6 +2878,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -2873,11 +2900,12 @@ exports[`<CurrencyField /> should render properly 6`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="00.000.000,00 €"
-              value=""
+              value="0,00 €"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="DE"
                 deferredValidationTime={200}
                 disabled={false}
@@ -2898,10 +2926,10 @@ exports[`<CurrencyField /> should render properly 6`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="0,00 €"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -3069,6 +3097,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -3108,6 +3137,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -3137,7 +3167,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
                         onInput={[Function]}
                         placeholder="00.000.000,00 €"
                         type="text"
-                        value=""
+                        value="0,00 €"
                       />
                     </div>
                   </div>
@@ -3150,7 +3180,7 @@ exports[`<CurrencyField /> should render properly 6`] = `
     </Component>
     <input
       type="hidden"
-      value="€0.00"
+      value="0,00 €"
     />
   </div>
 </CurrencyField>
@@ -3177,7 +3207,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="00.000.000,00 €"
-      value=""
+      value="0,00 €"
     >
       <CustomizedFabric>
         <Fabric
@@ -3339,6 +3369,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -3378,6 +3409,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -3399,11 +3431,12 @@ exports[`<CurrencyField /> should render properly 7`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="00.000.000,00 €"
-              value=""
+              value="0,00 €"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="ES"
                 deferredValidationTime={200}
                 disabled={false}
@@ -3424,10 +3457,10 @@ exports[`<CurrencyField /> should render properly 7`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="0,00 €"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -3595,6 +3628,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -3634,6 +3668,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -3663,7 +3698,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
                         onInput={[Function]}
                         placeholder="00.000.000,00 €"
                         type="text"
-                        value=""
+                        value="0,00 €"
                       />
                     </div>
                   </div>
@@ -3676,7 +3711,7 @@ exports[`<CurrencyField /> should render properly 7`] = `
     </Component>
     <input
       type="hidden"
-      value="€0.00"
+      value="0,00 €"
     />
   </div>
 </CurrencyField>
@@ -3703,7 +3738,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="₹ 00,00,000.00"
-      value=""
+      value="₹ 0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -3865,6 +3900,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -3904,6 +3940,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -3925,11 +3962,12 @@ exports[`<CurrencyField /> should render properly 8`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="₹ 00,00,000.00"
-              value=""
+              value="₹ 0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="IN"
                 deferredValidationTime={200}
                 disabled={false}
@@ -3950,10 +3988,10 @@ exports[`<CurrencyField /> should render properly 8`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="₹ 0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -4121,6 +4159,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -4160,6 +4199,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -4189,7 +4229,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
                         onInput={[Function]}
                         placeholder="₹ 00,00,000.00"
                         type="text"
-                        value=""
+                        value="₹ 0.00"
                       />
                     </div>
                   </div>
@@ -4202,7 +4242,7 @@ exports[`<CurrencyField /> should render properly 8`] = `
     </Component>
     <input
       type="hidden"
-      value="₹0.00"
+      value="₹ 0.00"
     />
   </div>
 </CurrencyField>
@@ -4229,7 +4269,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
       onChanged={[Function]}
       onFocus={[Function]}
       placeholder="£00,000,000.00"
-      value=""
+      value="£0.00"
     >
       <CustomizedFabric>
         <Fabric
@@ -4391,6 +4431,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
                 "buttonTextDisabled": "#d0d0d0",
                 "buttonTextHovered": "#000000",
                 "buttonTextPressed": "#212121",
+                "defaultStateBackground": "#eaeaea",
                 "disabledBackground": "#f4f4f4",
                 "disabledBodyText": "#c8c8c8",
                 "disabledSubtext": "#d0d0d0",
@@ -4430,6 +4471,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
                 "smallInputBorder": "#666666",
                 "successBackground": "rgba(186, 216, 10, .2)",
                 "variantBorder": "#eaeaea",
+                "variantBorderHovered": "#a6a6a6",
                 "warningBackground": "rgba(255, 185, 0, .2)",
                 "warningHighlight": "#ffb900",
                 "warningText": "#333333",
@@ -4451,11 +4493,12 @@ exports[`<CurrencyField /> should render properly 9`] = `
               onChanged={[Function]}
               onFocus={[Function]}
               placeholder="£00,000,000.00"
-              value=""
+              value="£0.00"
             >
               <TextField
                 autoAdjustHeight={false}
                 borderless={false}
+                className="undefined "
                 countryCode="GB"
                 deferredValidationTime={200}
                 disabled={false}
@@ -4476,10 +4519,10 @@ exports[`<CurrencyField /> should render properly 9`] = `
                 validateOnFocusIn={false}
                 validateOnFocusOut={false}
                 validateOnLoad={true}
-                value=""
+                value="£0.00"
               >
                 <div
-                  className="ms-TextField root"
+                  className="ms-TextField root undefined "
                 >
                   <div
                     className="ms-TextField-wrapper wrapper"
@@ -4647,6 +4690,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
                               "buttonTextDisabled": "#d0d0d0",
                               "buttonTextHovered": "#000000",
                               "buttonTextPressed": "#212121",
+                              "defaultStateBackground": "#eaeaea",
                               "disabledBackground": "#f4f4f4",
                               "disabledBodyText": "#c8c8c8",
                               "disabledSubtext": "#d0d0d0",
@@ -4686,6 +4730,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
                               "smallInputBorder": "#666666",
                               "successBackground": "rgba(186, 216, 10, .2)",
                               "variantBorder": "#eaeaea",
+                              "variantBorderHovered": "#a6a6a6",
                               "warningBackground": "rgba(255, 185, 0, .2)",
                               "warningHighlight": "#ffb900",
                               "warningText": "#333333",
@@ -4715,7 +4760,7 @@ exports[`<CurrencyField /> should render properly 9`] = `
                         onInput={[Function]}
                         placeholder="£00,000,000.00"
                         type="text"
-                        value=""
+                        value="£0.00"
                       />
                     </div>
                   </div>

--- a/packages/core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
+++ b/packages/core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.js.snap
@@ -8,7 +8,7 @@ exports[`<DatePicker /> should render properly 1`] = `
     className="ms-Fabric root-33"
   >
     <div
-      className="ms-TextField root"
+      className="ms-TextField root undefined "
     >
       <div
         className="ms-TextField-wrapper wrapper"
@@ -124,7 +124,7 @@ exports[`<DatePicker /> should render when value prop passed 1`] = `
     className="ms-Fabric root-33"
   >
     <div
-      className="ms-TextField root"
+      className="ms-TextField root undefined "
     >
       <div
         className="ms-TextField-wrapper wrapper"

--- a/packages/core/src/components/HierarchySelector/__tests__/__snapshots__/HierarchySelector.test.js.snap
+++ b/packages/core/src/components/HierarchySelector/__tests__/__snapshots__/HierarchySelector.test.js.snap
@@ -60,7 +60,7 @@ exports[`<HierarchySelector /> should render nested options properly 1`] = `
       className="ms-Fabric root-33"
     >
       <div
-        className="ms-TextField root"
+        className="ms-TextField root undefined "
       >
         <div
           className="ms-TextField-wrapper wrapper"

--- a/packages/core/src/components/PhoneNumber/__tests__/__snapshots__/phoneNumber.test.js.snap
+++ b/packages/core/src/components/PhoneNumber/__tests__/__snapshots__/phoneNumber.test.js.snap
@@ -177,6 +177,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -216,6 +217,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -240,6 +242,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="US"
               deferredValidationTime={200}
@@ -262,7 +265,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -430,6 +433,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -469,6 +473,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 1`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -689,6 +694,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -728,6 +734,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -752,6 +759,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="UK"
               deferredValidationTime={200}
@@ -774,7 +782,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -942,6 +950,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -981,6 +990,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 2`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -1201,6 +1211,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -1240,6 +1251,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -1264,6 +1276,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="IR"
               deferredValidationTime={200}
@@ -1286,7 +1299,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -1454,6 +1467,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -1493,6 +1507,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 3`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -1713,6 +1728,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -1752,6 +1768,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -1776,6 +1793,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="ME"
               deferredValidationTime={200}
@@ -1798,7 +1816,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -1966,6 +1984,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -2005,6 +2024,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 4`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -2225,6 +2245,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -2264,6 +2285,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -2288,6 +2310,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="CA"
               deferredValidationTime={200}
@@ -2310,7 +2333,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -2478,6 +2501,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -2517,6 +2541,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 5`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -2737,6 +2762,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -2776,6 +2802,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -2800,6 +2827,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="DE"
               deferredValidationTime={200}
@@ -2822,7 +2850,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -2990,6 +3018,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -3029,6 +3058,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 6`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -3249,6 +3279,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -3288,6 +3319,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -3312,6 +3344,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="ES"
               deferredValidationTime={200}
@@ -3334,7 +3367,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -3502,6 +3535,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -3541,6 +3575,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 7`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -3761,6 +3796,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -3800,6 +3836,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -3824,6 +3861,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="IN"
               deferredValidationTime={200}
@@ -3846,7 +3884,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -4014,6 +4052,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -4053,6 +4092,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 8`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -4273,6 +4313,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -4312,6 +4353,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -4336,6 +4378,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="GB"
               deferredValidationTime={200}
@@ -4358,7 +4401,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
               value="+"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -4526,6 +4569,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -4565,6 +4609,7 @@ exports[`<PhoneNumber /> should render properly for various country codes 9`] = 
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",
@@ -4786,6 +4831,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
               "buttonTextDisabled": "#d0d0d0",
               "buttonTextHovered": "#000000",
               "buttonTextPressed": "#212121",
+              "defaultStateBackground": "#eaeaea",
               "disabledBackground": "#f4f4f4",
               "disabledBodyText": "#c8c8c8",
               "disabledSubtext": "#d0d0d0",
@@ -4825,6 +4871,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
               "smallInputBorder": "#666666",
               "successBackground": "rgba(186, 216, 10, .2)",
               "variantBorder": "#eaeaea",
+              "variantBorderHovered": "#a6a6a6",
               "warningBackground": "rgba(255, 185, 0, .2)",
               "warningHighlight": "#ffb900",
               "warningText": "#333333",
@@ -4849,6 +4896,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
             <TextField
               autoAdjustHeight={false}
               borderless={false}
+              className="undefined "
               componentRef={[Function]}
               countryCode="de"
               deferredValidationTime={200}
@@ -4871,7 +4919,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
               value="+7 793 847 41"
             >
               <div
-                className="ms-TextField root"
+                className="ms-TextField root undefined "
               >
                 <div
                   className="ms-TextField-wrapper wrapper"
@@ -5039,6 +5087,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
                             "buttonTextDisabled": "#d0d0d0",
                             "buttonTextHovered": "#000000",
                             "buttonTextPressed": "#212121",
+                            "defaultStateBackground": "#eaeaea",
                             "disabledBackground": "#f4f4f4",
                             "disabledBodyText": "#c8c8c8",
                             "disabledSubtext": "#d0d0d0",
@@ -5078,6 +5127,7 @@ exports[`<PhoneNumber /> should render properly with value set 1`] = `
                             "smallInputBorder": "#666666",
                             "successBackground": "rgba(186, 216, 10, .2)",
                             "variantBorder": "#eaeaea",
+                            "variantBorderHovered": "#a6a6a6",
                             "warningBackground": "rgba(255, 185, 0, .2)",
                             "warningHighlight": "#ffb900",
                             "warningText": "#333333",

--- a/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.test.js.snap
+++ b/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.test.js.snap
@@ -5,7 +5,7 @@ exports[`<TextField /> <TextField /> should render properly 1`] = `
   className="ms-Fabric root-33"
 >
   <div
-    className="ms-TextField root"
+    className="ms-TextField root undefined "
   >
     <div
       className="ms-TextField-wrapper wrapper"


### PR DESCRIPTION
Upon running yarn test I noticed that 3 tests in CurrencyField.test.js were failing so I decided to take a look. I found that several test values were formatted incorrectly (mainly commas/periods, i.e 99.99 should have been 99,99) and so I corrected them. After that I found that the tests were still failing, which ended up being an issue with the formatting returned by Intl.NumberFormat which is used by formatCurrency in currencyUtils.js. The problem is that the formatter returns a non-breaking-space on the left and the right of certain currency symbols, so I corrected the test cases so they would work properly.

![40359336_258989008063801_360805724202205184_n 1](https://user-images.githubusercontent.com/10966992/44842494-a1903380-ac0b-11e8-8066-1cad91462399.png)
